### PR TITLE
Remove unnecessary `into_iter` from `find_max_k` in `leetcode_2441.rs`

### DIFF
--- a/leetcode_rust/src/leetcode_2441.rs
+++ b/leetcode_rust/src/leetcode_2441.rs
@@ -1,0 +1,17 @@
+use std::collections::HashSet;
+#[allow(dead_code)]
+pub struct Solution;
+#[allow(dead_code)]
+impl Solution {
+    pub fn find_max_k(nums: Vec<i32>) -> i32 {
+        let mut nums_set = HashSet::new();
+        let mut max_k = -1;
+        for num in nums {
+            if nums_set.contains(&-num) {
+                max_k = max_k.max(num.abs());
+            }
+            nums_set.insert(num);
+        }
+        max_k
+    }
+}

--- a/leetcode_rust/src/main.rs
+++ b/leetcode_rust/src/main.rs
@@ -1,4 +1,5 @@
 mod two_sum;
+mod leetcode_2441;
 
 fn main() {
     println!("Hello World");
@@ -6,12 +7,20 @@ fn main() {
 
 #[cfg(test)]
 mod test {
-    use crate::two_sum::Solution;
+    use crate::two_sum;
+    use crate::leetcode_2441;
 
     #[test]
     fn test_two_sum() {
-        let mut two_sum_res = Solution::two_sum(vec![2,7,11,15], 9);
+        let mut two_sum_res = two_sum::Solution::two_sum(vec![2,7,11,15], 9);
         two_sum_res.sort();
         assert_eq!(vec![0, 1], two_sum_res);
+    }
+
+    #[test]
+    fn test_leetcode_2441() {
+        assert_eq!(3, leetcode_2441::Solution::find_max_k(vec![-1, 2, -3, 3]));
+        assert_eq!(7, leetcode_2441::Solution::find_max_k(vec![-1,10,6,7,-7,1]));
+        assert_eq!(-1, leetcode_2441::Solution::find_max_k(vec![-10,8,6,7,-2,-3]));
     }
 }


### PR DESCRIPTION
- Remove unnecessary `into_iter` from `find_max_k` in `leetcode_2441.rs`.